### PR TITLE
Improvements to metric rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
                 <div id="cc-condition" class="regular-text cc-text">Condition</div>
                 <div class="cc-horizontal-group">
                   <div class="regular-text cc-text cc-left">VISIBILITY</div>
-                  <div class="regular-text cc-text"><span id="cc-visibility">0</span> Miles</div>
+                  <div class="regular-text cc-text"><span id="cc-visibility">0</span> <span id="cc-visibility-unit-imperial">Miles</span><span id="cc-visibility-unit-metric">km</span></div>
                 </div>
               </div>
             </div>
@@ -181,7 +181,7 @@
                 </div>
                 <div class="cc-horizontal-group">
                   <div class="regular-text cc-text cc-left">PRESSURE</div>
-                  <div class="regular-text cc-text"><span id="cc-pressure1">29</span>.<span id="cc-pressure2">92</span><span id="cc-pressuretrend">▲</span></div>
+                  <div class="regular-text cc-text"><span id="cc-pressure1">29</span><span id="cc-pressure-decimal">.</span><span id="cc-pressure2">92</span><span id="cc-pressure-metric"> mbar</span><span id="cc-pressuretrend">▲</span></div>
                 </div>
               </div>
             </div>

--- a/js/MainScript.js
+++ b/js/MainScript.js
@@ -266,10 +266,27 @@ function scrollCC(){
   // Split decimal into 2 objects so that we can animate them individually.
   var pressureArray = pressure.toString().split('.');
   animateValue("cc-visibility", 0, visibility, 800, 1);
+  if(CONFIG.units != 'm') {
+	  getElement("cc-visibility-unit-metric").style.fontSize = "0px";		//Doing the work twice, for good reason: if we simply hide it, the spacing left by the word still exists; if we simply set the size to zero, then it might still be visible at extreme zoom levels.
+	  getElement("cc-visibility-unit-metric").style.visibility = "hidden";
+  } else {
+	  getElement("cc-visibility-unit-imperial").style.fontSize = "0px";
+	  getElement("cc-visibility-unit-imperial").style.visibility = "hidden";
+  }
   animateValue("cc-humidity", 0, humidity, 1000, 1);
   animateValue("cc-dewpoint", 0, dewPoint, 1200, 1);
-  animateValue("cc-pressure1", 0, pressureArray[0], 1400, 1);
-  animateValue("cc-pressure2", 0, pressureArray[1], 1400, 2);
+  if (CONFIG.units === 'e') {		//Imperial units.
+	animateValue("cc-pressure1", 0, pressureArray[0], 1300, 1);
+	animateValue("cc-pressure2", 0, pressureArray[1], 1300, 2);
+	getElement("cc-pressure-metric").style.fontSize = "0px";		//hide the "mbar" tag
+	getElement("cc-pressure-metric").style.visibility = "hidden";
+  } else {		//Metric units.
+	  animateValue("cc-pressure1", 800, pressureArray[0], 1200, 3);
+	  getElement("cc-pressure2").style.visibility = "hidden";		//Hide figures after the decimal, since we don't really use decimal points when using hectopascals in the context of meteorology
+	  getElement("cc-pressure2").style.fontSize = "0px";
+	  getElement("cc-pressure-decimal").style.visibility = "hidden";		//And same for the decimal, which would look silly without something after it.
+	  getElement("cc-pressure-decimal").style.fontSize = "0px";
+  }
 }
 
 // Called at end of sequence. Animates everything out and shows ending text

--- a/js/MainScript.js
+++ b/js/MainScript.js
@@ -267,25 +267,25 @@ function scrollCC(){
   var pressureArray = pressure.toString().split('.');
   animateValue("cc-visibility", 0, visibility, 800, 1);
   if(CONFIG.units != 'm') {
-	  getElement("cc-visibility-unit-metric").style.fontSize = "0px";		//Doing the work twice, for good reason: if we simply hide it, the spacing left by the word still exists; if we simply set the size to zero, then it might still be visible at extreme zoom levels.
-	  getElement("cc-visibility-unit-metric").style.visibility = "hidden";
+      getElement("cc-visibility-unit-metric").style.fontSize = "0px";		//Doing the work twice, for good reason: if we simply hide it, the spacing left by the word still exists; if we simply set the size to zero, then it might still be visible at extreme zoom levels.
+      getElement("cc-visibility-unit-metric").style.visibility = "hidden";
   } else {
-	  getElement("cc-visibility-unit-imperial").style.fontSize = "0px";
-	  getElement("cc-visibility-unit-imperial").style.visibility = "hidden";
+      getElement("cc-visibility-unit-imperial").style.fontSize = "0px";
+      getElement("cc-visibility-unit-imperial").style.visibility = "hidden";
   }
   animateValue("cc-humidity", 0, humidity, 1000, 1);
   animateValue("cc-dewpoint", 0, dewPoint, 1200, 1);
   if (CONFIG.units === 'e') {		//Imperial units.
-	animateValue("cc-pressure1", 0, pressureArray[0], 1300, 1);
-	animateValue("cc-pressure2", 0, pressureArray[1], 1300, 2);
-	getElement("cc-pressure-metric").style.fontSize = "0px";		//hide the "mbar" tag
-	getElement("cc-pressure-metric").style.visibility = "hidden";
-  } else {		//Metric units.
-	  animateValue("cc-pressure1", 800, pressureArray[0], 1200, 3);
-	  getElement("cc-pressure2").style.visibility = "hidden";		//Hide figures after the decimal, since we don't really use decimal points when using hectopascals in the context of meteorology
-	  getElement("cc-pressure2").style.fontSize = "0px";
-	  getElement("cc-pressure-decimal").style.visibility = "hidden";		//And same for the decimal, which would look silly without something after it.
-	  getElement("cc-pressure-decimal").style.fontSize = "0px";
+    animateValue("cc-pressure1", 0, pressureArray[0], 1400, 1);
+    animateValue("cc-pressure2", 0, pressureArray[1], 1400, 2);
+    getElement("cc-pressure-metric").style.fontSize = "0px";		//hide the "mbar" tag
+    getElement("cc-pressure-metric").style.visibility = "hidden";
+  } else {      //Metric units.
+      animateValue("cc-pressure1", 800, pressureArray[0], 1400, 3);
+      getElement("cc-pressure2").style.visibility = "hidden";		//Hide figures after the decimal, since we don't really use decimal points when using hectopascals in the context of meteorology
+      getElement("cc-pressure2").style.fontSize = "0px";
+      getElement("cc-pressure-decimal").style.visibility = "hidden";		//And same for the decimal, which would look silly without something after it.
+      getElement("cc-pressure-decimal").style.fontSize = "0px";
   }
 }
 

--- a/js/WeatherFetching.js
+++ b/js/WeatherFetching.js
@@ -139,7 +139,7 @@ function fetchCurrentWeather(){
               let unit = data.observation[CONFIG.unitField];
               currentTemperature = Math.round(unit.temp);
               currentCondition = data.observation.phrase_32char;
-              windSpeed = `${data.observation.wdir_cardinal} ${unit.wspd} ${CONFIG.unit === 'm' ? 'km/h' : 'mph'}`;
+              windSpeed = `${data.observation.wdir_cardinal} ${unit.wspd} ${CONFIG.units === 'm' ? 'km/h' : 'mph'}`;
               gusts = unit.gust || 'NONE';
               feelsLike = unit.feels_like
               visibility = Math.round(unit.vis)


### PR DESCRIPTION
## Overview

### Cliffnotes version

- Fixes an issue where wind speed will always show MPH regardless of units used.
- Fixes an issue where pressure will show xxxx.-xxxx when using metric.
- Fixes an issue where metric pressures won't fully increment before disappearing.
- Fixes an issue where visibility will always show miles regardless of units used.

### Full version

Currently, metric rendering in the Current Conditions screens is a bit messy. Assuming a day with visibility greater than 10 miles (16 km) and standard atmospheric pressure (29,92 inHg / 1013 hPa), the second screen of the Current Conditions will show:
- VISIBILITY 16 Miles
- PRESSURE 1013.-1013

(This assumes that the Pressure display finishes counting that high, as its current starting point of zero does not quite give it enough time to finish tallying, with a suitable gap to be read, before disappearing.)

In addition, there is an issue with the wind in the first screen of the Current Conditions where the wind speed will show "mph" as the unit, regardless of the configuration's setting.

## Notes

- When a span is hidden from view, it is both hidden and resized to "zero pixels". The work is done twice for a reason: simply hiding the span would leave a giant, hidden-text-sized gap in the middle of things, and simply resizing the span to zero pixels would potentially create an edge case where text that's supposed to be "hidden" could be visible at absurd zoom levels or screen resolutions.
- When using metric units, the "count-up" animation starts at 800 hPa (23,62 inHg) to allow there to be enough time for it to finish incrementing and be read before disappearing. 
- The "mbar" in the pressure display is purely for aesthetic purposes. It feels strange without it, to me, but that could just be me.
- I am not proficient in JavaScript, but it's close enough to what I'm used to that I can read it. I didn't see any issues during local testing, but I would absolutely appreciate it if someone who's more proficient at JavaScript than I am could give it another test run.

## Complete list of changes made

- index.html
  - GENERAL: All changes listed below are made into their own spans, to allow them to be hidden and resized as necessary.
  - PRESSURE: Made the decimal point (for imperial measures) its own span.
  - PRESSURE: Added an ` mbar` flag for use when displaying metric, for aesthetic purposes.
  - VISIBILITY: Made the "Miles" unit its own span.
  - VISIBILITY: Added a "km" unit for use when displaying metric.
-  js/MainScript.js
  - Added unit flag switching to visibility and air pressure.
  - Air pressure levels start counting up at 800 if the pressure units are set to hectopascals.
- js/WeatherFetching.js
  - Line 142: Added missing letter "s" onto `CONFIG.unit`.

## Screenshots
### Metric mode (`units = 'm'`)
![image](https://user-images.githubusercontent.com/1784490/209644997-655d1cfa-5672-46c1-a010-1e0c2f26e50b.png)
*First screen of Current Conditions, set to use metric. The wind speed is stated to be five kilometres per hour.*

---
![image](https://user-images.githubusercontent.com/1784490/209645007-32664bb2-b26e-49e5-9227-80bc979ba3f1.png)
*Second screen of Current Conditions, set to use metric. The visibility is stated to be 16 kilometres, and the air pressure is 1027 millibars.*

---
### US mode (`units = 'e'`)
![image](https://user-images.githubusercontent.com/1784490/209645224-927f7701-3f55-42c8-a0df-955df1b69cc2.png)
*First screen of Current Conditions, set to use US measures. The wind speed is stated to be three miles per hour.*

---
![image](https://user-images.githubusercontent.com/1784490/209645360-141faa2b-48c4-48bb-9de7-4f5f4bcdd966.png)
*Second screen of the Current Conditions, set to use US measures. The visibility is stated to be 10 miles, and the air pressure is 30.32 inches mercury.*