### PR TITLE
Add Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git/
+README.md
+LICENSE
+.github/
+.gitmodules
+Dockerfile
+.dockerignore
+.gitignore
+screenshots/
+docs/

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -5,6 +5,9 @@ jobs:
   build:
     name: Build Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - id: short-sha
-        uses: benjlevesque/short-sha@v1.2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -19,7 +17,7 @@ jobs:
           tags: |
             type=raw,priority=1000,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             type=ref,event=branch
-            ${{ steps.short-sha.outputs.sha }}
+            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Buildx

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,44 @@
+name: build-docker
+on: push
+
+jobs:
+  build:
+    name: Build Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: short-sha
+        uses: benjlevesque/short-sha@v1.2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/qconrad/intellistar-emulator
+          tags: |
+            type=raw,priority=1000,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=ref,event=branch
+            ${{ steps.short-sha.outputs.sha }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          pull: true
+          push: ${{ github.ref == 'refs/heads/master' }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY . /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ This is a local forecast segment that airs on The Weather Channel called the "Lo
 4. Click start
 5. Press F11 for fullscreen
 
+## Option 3 (Docker)
+1. `docker run -p 8080:80 ghcr.io/qconrad/intellistar-emulator`
+2. Visit: http://localhost:8080
+3. Enter zip code
+4. Click start
+5. Press F11 for fullscreen
+
 ## Features
 Most of core animation and logic has been replicated including severe weather alerts, forecast descriptions, crawl text, and the Doppler radar map.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A web application that displays weather information in the same visual presentation as the cable headend unit [Intellistar](https://en.wikipedia.org/wiki/IntelliStar).
 
 ## Overview
-This is a local forecast segment that airs on The Weather Channel called the "Local on the 8s". The name is because it airs at timeslots that end in "8" (9:28, 2:48, etc.). The forecast is approximately a minute long and provides information on current and forecasted weather conditions. This type of forecast started in 1982 using WeatherStar units. It was later upgraded to Intellistar in 2003 and recieved various graphic changes over the years. This emulator uses the style that started in 2013.
+This is a local forecast segment that airs on The Weather Channel called the "Local on the 8s". The name is because it airs at timeslots that end in "8" (9:28, 2:48, etc.). The forecast is approximately a minute long and provides information on current and forecasted weather conditions. This type of forecast started in 1982 using WeatherStar units. It was later upgraded to Intellistar in 2003 and received various graphic changes over the years. This emulator uses the style that started in 2013.
 
 ## Instructions
 ## Option 1 (easier)


### PR DESCRIPTION
This PR adds a Dockerfile to build and run the project, a GitHub Action to build the Docker image, and a container repository at ghcr.io/qconrad/intellistar-emulator.

Additionally, I've added a Docker example in the readme.

### After Merge

The package repository will be created automatically during the first run, but may default to private visibility. If so, you will need to:

Go to https://ghcr.io/qconrad/intellistar-emulator
Package Settings
Change package visibility
Set to Public
After changing visibility, I'd also suggest that you go to this repo's homepage, click the settings cog on the right, then enable Packages on the homepage.