### PR TITLE
Radar Fix

### DIFF
--- a/css/radar.css
+++ b/css/radar.css
@@ -7,7 +7,9 @@
   transform: translateY(-50%);
   text-align: center;
 }
-
+.radar-container{
+  overflow: hidden;
+}
 .key{
   display: inline-block;
   float: right;

--- a/index.html
+++ b/index.html
@@ -192,46 +192,10 @@
       <!-- Radar Page -->
       <div id="radar-page" class="page-container regular-page-container">
         <div class="page-title-bar regular-text">
-          <div style="display: inline-block">3 Hour Radar</div>
-          <div class="key">
-            <div class="key-item key-item-snow">
-              <div class="key-color-group">
-                <div class="key-color" style="background-color: #91fdfd;"></div>
-                <div class="key-color" style="background-color: #59aaab;"></div>
-                <div class="key-color" style="background-color: #3f7c7d;"></div>
-                <div class="key-color" style="background-color: #14303b;"></div>
-              </div>
-              <div class="key-label">Snow</div>
-            </div>
-          </div>
-          <div class="key">
-            <div class="key-item key-item-mix">
-              <div class="key-color-group">
-                <div class="key-color" style="background-color: #fe94ce;"></div>
-                <div class="key-color" style="background-color: #cf5597;"></div>
-                <div class="key-color" style="background-color: #a01765;"></div>
-              </div>
-              <div class="key-label">Mix/Ice</div>
-            </div>
-          </div>
-          <div class="key">
-            <div class="key-item key-item-rain">
-              <div class="key-color-group">
-                <div class="key-color" style="background-color: #69ff63;"></div>
-                <div class="key-color" style="background-color: #19791d;"></div>
-                <div class="key-color" style="background-color: #f9fe02;"></div>
-                <div class="key-color" style="background-color: #ea6905;"></div>
-                <div class="key-color" style="background-color: #9c0506;"></div>
-              </div>
-              <div class="key-label">Rain</div>
-            </div>
-          </div>
+          <div style="display: inline-block">2 Hour Radar</div>
         </div>
         <div class="page-content-container">
-          <div class="broken-radar-text">
-            <div style="color: yellow;" class="strong-text">Temporarily Unavailable</div>
-          </div>
-          <div id="radar-container" style="position: absolute;">
+          <div id="radar-container" class="radar-container" style="position: absolute;">
           </div>
         </div>
       </div>
@@ -239,46 +203,10 @@
       <!-- Zoomed Radar Page -->
       <div id="zoomed-radar-page" class="page-container regular-page-container">
         <div class="page-title-bar regular-text">
-          <div style="display: inline-block">3 Hour Radar</div>
-          <div class="key">
-            <div class="key-item key-item-snow">
-              <div class="key-color-group">
-                <div class="key-color" style="background-color: #91fdfd;"></div>
-                <div class="key-color" style="background-color: #59aaab;"></div>
-                <div class="key-color" style="background-color: #3f7c7d;"></div>
-                <div class="key-color" style="background-color: #14303b;"></div>
-              </div>
-              <div class="key-label">Snow</div>
-            </div>
-          </div>
-          <div class="key">
-            <div class="key-item key-item-mix">
-              <div class="key-color-group">
-                <div class="key-color" style="background-color: #fe94ce;"></div>
-                <div class="key-color" style="background-color: #cf5597;"></div>
-                <div class="key-color" style="background-color: #a01765;"></div>
-              </div>
-              <div class="key-label">Mix/Ice</div>
-            </div>
-          </div>
-          <div class="key">
-            <div class="key-item key-item-rain">
-              <div class="key-color-group">
-                <div class="key-color" style="background-color: #69ff63;"></div>
-                <div class="key-color" style="background-color: #19791d;"></div>
-                <div class="key-color" style="background-color: #f9fe02;"></div>
-                <div class="key-color" style="background-color: #ea6905;"></div>
-                <div class="key-color" style="background-color: #9c0506;"></div>
-              </div>
-              <div class="key-label">Rain</div>
-            </div>
-          </div>
+          <div style="display: inline-block">2 Hour Radar</div>
         </div>
         <div class="page-content-container">
-          <div class="broken-radar-text">
-            <div style="color: yellow;" class="strong-text">Temporarily Unavailable</div>
-          </div>
-          <div id="zoomed-radar-container" style="position: absolute;"></div>
+          <div id="zoomed-radar-container" class="radar-container" style="position: absolute;"></div>
         </div>
       </div>
 

--- a/js/Config.js
+++ b/js/Config.js
@@ -1,5 +1,5 @@
 window.CONFIG = {
-  crawl: `Due to the discontinuation of Weather Underground's API, severe weather alerts, automatic geolookup, and doppler radar imagery are broken for now.`,
+  crawl: `Thanks to all the contributors of this project. While it's not completely finished, the community effort has made this possible. Stars, contributions, and feedback are welcome and appreciated. Thanks for trying out this emulator.`,
   greeting: 'This is your weather',
   language: 'en-US', // Supported in TWC API
   countryCode: 'US', // Supported in TWC API (for postal key)

--- a/js/WeatherFetching.js
+++ b/js/WeatherFetching.js
@@ -158,22 +158,79 @@ function fetchCurrentWeather(){
 }
 
 function fetchRadarImages(){
-  // Skip radar until replaced with some other solution (wunderground api dead)
-  scheduleTimeline();
-  return;
-
-  radarImage = new Image();
+  radarImage = document.createElement("iframe");
   radarImage.onerror = function () {
     getElement('radar-container').style.display = 'none';
   }
-  radarImage.src = `https://api.wunderground.com/api/${CONFIG.secrets.wundergroundAPIKey}/animatedradar/q/MI/${zipCode}.gif?newmaps=1&timelabel=1&timelabel.y=10&num=5&delay=10&radius=100&num=15&width=1235&height=525&rainsnow=1&smoothing=1&noclutter=1`;
 
+  mapSettings = btoa(JSON.stringify({
+    "agenda": {
+      "id": "weather",
+      "center": [longitude, latitude],
+      "location": null,
+      "zoom": 8
+    },
+    "animating": true,
+    "base": "standard",
+    "artcc": false,
+    "county": false,
+    "cwa": false,
+    "rfc": false,
+    "state": false,
+    "menu": false,
+    "shortFusedOnly": false,
+    "opacity": {
+      "alerts": 0.0,
+      "local": 0.0,
+      "localStations": 0.0,
+      "national": 0.6
+    }
+  }));
+  radarImage.setAttribute("src", "https://radar.weather.gov/?settings=v1_" + mapSettings);
+  radarImage.style.width = "1230px"
+  radarImage.style.height = "740px"
+  radarImage.style.marginTop = "-220px"
+  radarImage.style.overflow = "hidden"
+  
   if(alertsActive){
     zoomedRadarImage = new Image();
     zoomedRadarImage.onerror = function () {
       getElement('zoomed-radar-container').style.display = 'none';
     }
-    zoomedRadarImage.src = `https://api.wunderground.com/api/${CONFIG.secrets.wundergroundAPIKey}/animatedradar/q/MI/${zipCode}.gif?newmaps=1&timelabel=1&timelabel.y=10&num=5&delay=10&radius=50&num=15&width=1235&height=525&rainsnow=1&smoothing=1&noclutter=1`;
+
+    zoomedRadarImage = document.createElement("iframe");
+    zoomedRadarImage.onerror = function () {
+      getElement('zoomed-radar-container').style.display = 'none';
+    }
+  
+    mapSettings = btoa(JSON.stringify({
+      "agenda": {
+        "id": "weather",
+        "center": [longitude, latitude],
+        "location": null,
+        "zoom": 10
+      },
+      "animating": true,
+      "base": "standard",
+      "artcc": false,
+      "county": false,
+      "cwa": false,
+      "rfc": false,
+      "state": false,
+      "menu": false,
+      "shortFusedOnly": false,
+      "opacity": {
+        "alerts": 0.0,
+        "local": 0.0,
+        "localStations": 0.0,
+        "national": 0.6
+      }
+    }));
+    zoomedRadarImage.setAttribute("src", "https://radar.weather.gov/?settings=v1_" + mapSettings);
+    zoomedRadarImage.style.width = "1230px"
+    zoomedRadarImage.style.height = "740px"
+    zoomedRadarImage.style.marginTop = "-220px"
+    zoomedRadarImage.style.overflow = "hidden"
   }
 
   scheduleTimeline();


### PR DESCRIPTION
This PR switches the radar to use the NWS radar.weather.gov page inside an iframe. It also supports an increased zoom while alerts are active. 

I did remove the original precip legend, as the NWS page has its own with timestamps included. If we want to preserve the look of the original, I can mess around with the iframe more to see if I can remove the NWS legend. It also does seem to be 2 hr radar, so I updated the title to reflect that.

I took some inspiration from [BennyDaBee's](https://github.com/BennyDaBee/intellistar-emulator) radar solution and generalized and iterated on it.

Fixes #20 #31 #32 
![Radar Screenshot](https://user-images.githubusercontent.com/10804314/232253635-43b55dcd-6594-4429-a827-675c7cb654c8.png)
