### PR TITLE
Alerts Fix

### DIFF
--- a/js/Config.js
+++ b/js/Config.js
@@ -1,5 +1,5 @@
 window.CONFIG = {
-  crawl: `Due to the discontinuation of Weather Underground's API, severe weather alerts, automatic geolookup, and doppler radar imagery are broken for now.`,
+  crawl: `Thanks to all the contributors of this project. While it's not completely finished, the community effort has made this possible. Stars, contributions, and feedback are welcome and appreciated. Thanks for trying out this emulator.`,
   greeting: 'This is your weather',
   language: 'en-US', // Supported in TWC API
   countryCode: 'US', // Supported in TWC API (for postal key)

--- a/js/WeatherFetching.js
+++ b/js/WeatherFetching.js
@@ -30,36 +30,34 @@ function guessZipCode(){
 }
 
 function fetchAlerts(){
-  // Skip alert fetching until replaced with TWC (wunderground api dead)
-  fetchForecast();
-  return;
-
   var alertCrawl = "";
-  // again, always use wunderground for fetching alerts
-  // two api calls are required for one alert
-  // one: GET v1/alerts
-  //        this gets all the alerts issued
-  // two: GET v1/alert/:detailKey/details.json
-  //        this gets the details of the alert
-  // will think of a solution later
-  // TODO: Use v1/alerts and v1/alert to grab alerts from TWC
-  fetch(`https://api.wunderground.com/api/${CONFIG.secrets.wundergroundAPIKey}/alerts/q/${zipCode}.json`)
+  fetch(`https://api.weather.gov/alerts/active?point=${latitude},${longitude}`)
     .then(function(response) {
       if (response.status !== 200) {
         console.log("forecast request error");
         return;
       }
       response.json().then(function(data) {
-        for(var i = 0; i < data.alerts.length; i++){
-          /* Take the most important alert message and set it as crawl text
-           This will supply more information i.e. tornado warning coverage */
-          alertCrawl = alertCrawl + " " + data.alerts[i].message.replace("...", "");
-
-          // ignore special weather statements
-          if(data.alerts[i].type == "SPE"){
-            continue;
+        if (data.features == undefined){
+          fetchForecast();
+          return;
+        }
+        if (data.features.length == 1) {
+          alerts[0] = data.features[0].properties.event + '<br>' + data.features[0].properties.description.replace("..."," ").replace(/\*/g, "")
+          for(var i = 0; i < data.features.length; i++){
+            /* Take the most important alert message and set it as crawl text
+            This will supply more information i.e. tornado warning coverage */
+            alertCrawl = alertCrawl + " " + data.features[i].properties.description.replace("...", " ");
           }
-          alerts[i] = data.alerts[i].message.replace("...", "").split("...", 1)[0].split("*", 1)[0].split("for", 1)[0].replace(/\n/g, " ").replace("...", "").toUpperCase();
+        }
+        else {
+          for(var i = 0; i < data.features.length; i++){
+            /* Take the most important alert message and set it as crawl text
+            This will supply more information i.e. tornado warning coverage */
+            alertCrawl = alertCrawl + " " + data.features[i].properties.description.replace("...", " ");
+
+            alerts[i] = data.features[i].properties.event
+          }
         }
         if(alertCrawl != ""){
           CONFIG.crawl = alertCrawl;


### PR DESCRIPTION
This PR switches alerts to use the NWS API. 

I took inspiration from [BennyDaBee's](https://github.com/BennyDaBee/intellistar-emulator) implementation of alerts, though theirs used OpenWeatherMap. I wanted to stick with NWS, since I used NWS for the radar source, and NWS doesn't need an API key.

Fixes #31 #32 

![Screenshot Single Alert](https://user-images.githubusercontent.com/10804314/232254169-f3ac482f-5242-41e3-b5c7-61a65e6b9b2f.png)
![Screenshot Multi Alert](https://user-images.githubusercontent.com/10804314/232254170-3e836c87-8d27-4e76-9d4d-5183b5447e4d.png)
