### PR TITLE
fix: loop and local storage fixes

### DIFF
--- a/js/Config.js
+++ b/js/Config.js
@@ -32,40 +32,54 @@ window.CONFIG = {
   },
   submit: (btn, e) => {
     let args = {}
+    const currentLoop = (localStorage.getItem('loop') === 'y')
     CONFIG.locationOptions.forEach((opt) => {
       args[opt.id] = getElement(`${opt.id}-text`).value
       args[`${opt.id}-button`] = getElement(`${opt.id}-button`).checked
-      localStorage.setItem(opt.id, args[opt.id])
+      if (!currentLoop) {
+        localStorage.setItem(opt.id, args[opt.id])
+      }
     })
     args['countryCode'] = getElement('country-code-text').value
+    if (!currentLoop) {
+      localStorage.setItem('countryCode', args['countryCode'])
+    }
     CONFIG.options.forEach((opt) => {
       args[opt.id] = getElement(`${opt.id}-text`).value
-      localStorage.setItem(opt.id, args[opt.id])
+      if (!currentLoop) {
+        localStorage.setItem(opt.id, args[opt.id])
+      }
     })
     console.log(args)
-    if (args.crawlText !== '') CONFIG.crawl = args.crawlText
-    if (args.greetingText !== '') CONFIG.greeting = args.greetingText
-    if(args.countryCode !== '') CONFIG.countryCode = args.countryCode
-    if (args.loop === 'y') CONFIG.loop = true
+    if (currentLoop) {
+      CONFIG.crawl = localStorage.getItem('crawlText')
+      CONFIG.greeting = localStorage.getItem('greetingText')
+      CONFIG.countryCode = localStorage.getItem('countryCode')
+    } else {
+      if (args.crawlText !== '') CONFIG.crawl = args.crawlText
+      if (args.greetingText !== '') CONFIG.greeting = args.greetingText
+      if (args.countryCode !== '') CONFIG.countryCode = args.countryCode
+      if (args.loop === 'y') CONFIG.loop = true
+    }
     
     if (args['airport-code-button']==true){ 
       CONFIG.locationMode="AIRPORT" 
       if(args['airport-code'].length==0){
         alert("Please enter an airport code")
-        return;
+        return
       }
     } 
     else { 
       CONFIG.locationMode="POSTAL" 
-      if(args['zip-code'].length==0){
+      if(!currentLoop && args['zip-code'].length==0){
         alert("Please enter a postal code")
-        return;
+        return
       }
 
     }
     
-    zipCode = args['zip-code'];
-    airportCode = args['airport-code'];
+    zipCode = args['zip-code'] || localStorage.getItem('zip-code')
+    airportCode = args['airport-code'] || localStorage.getItem('airport-code')
     
     CONFIG.unitField = CONFIG.units === 'm' ? 'metric' : (CONFIG.units === 'h' ? 'uk_hybrid' : 'imperial')
     fetchCurrentWeather();

--- a/js/Config.js
+++ b/js/Config.js
@@ -52,9 +52,9 @@ window.CONFIG = {
     })
     console.log(args)
     if (currentLoop) {
-      CONFIG.crawl = localStorage.getItem('crawlText')
-      CONFIG.greeting = localStorage.getItem('greetingText')
-      CONFIG.countryCode = localStorage.getItem('countryCode')
+      if (localStorage.getItem('crawlText')) CONFIG.crawl = localStorage.getItem('crawlText')
+      if (localStorage.getItem('greetingText')) CONFIG.greeting = localStorage.getItem('greetingText')
+      if (localStorage.getItem('countryCode')) CONFIG.countryCode = localStorage.getItem('countryCode')
     } else {
       if (args.crawlText !== '') CONFIG.crawl = args.crawlText
       if (args.greetingText !== '') CONFIG.greeting = args.greetingText


### PR DESCRIPTION
This PR **resolves** a regression caused from PR #44 that causes the looping feature to break, throwing a `Please enter a postal code` error.

![image](https://github.com/qconrad/intellistar-emulator/assets/1089554/38093059-da70-47f4-8788-2d6b2a0d11f7)

**Description of fix**
Config values were being set on each start, however the form isn't filled in on a loop refresh and "wipes" any previous values. Furthermore, the new validation assumes that values are from the form, not from localStorage. Checks are added if the application is in a loop state (from localStorage).  

This PR implements logic to handle loops for config validation & setting to localStorage.

**How to test**
- Open in a new session (no previous key/vals in localStorage).
- Input a zip code and press Start.
- Enable loop.
- Upon loop restart, it should no longer throw an error; emulator should replay.